### PR TITLE
Corrected package name in personal arti

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @transferwise/customer-understanding-data-science

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ _INSTALL_REQUIREMENTS = _parse_requirements(os.path.join(
     _CURRENT_DIR, "requirements", "requirements_prod.txt"))
 
 setup(
-    name="wise_lightweight_mmm",
+    name="lightweight_mmm",
     version=_VERSION,
     description="Package for Media-Mix-Modelling adapted from Google",
     long_description="\n".join([_README]),
@@ -67,14 +67,13 @@ setup(
     license="Apache 2.0",
     packages="lightweight_mmm",
     install_requires=_INSTALL_REQUIREMENTS,
-    url="https://github.com/transferwise/lightweight_mmm",
+    url="https://github.com/transferwise/wise-lightweight-mmm",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: Apache Software License",
         "Topic :: Scientific/Engineering :: Mathematics",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],


### PR DESCRIPTION
## Context
Arti package will be named lightweight_mmm for consistency. Python 3.8 is not supported. Jax is >=3.9
