### PR TITLE
Run on non-self hosted runner

### DIFF
--- a/.github/workflows/arti-publication.yaml
+++ b/.github/workflows/arti-publication.yaml
@@ -15,9 +15,7 @@ on:
 
 jobs:
   publish:
-    runs-on:
-      - self-hosted
-      - production
+    runs-on: ubuntu-latest
     container: docker.tw.ee/actions_python3_9
 
     steps:


### PR DESCRIPTION
## Context

Public repo's cannot run on self-hosted runners, this has now been changed.